### PR TITLE
Upgrade org.keycloak:keycloak-services from ${keycloak.version} to 26.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
         <version>26.2.0</version>
         </dependency>
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-server-spi-private</artifactId>
-            <version>${keycloak.version}</version>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-server-spi-private</artifactId>
+        <version>26.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,9 @@
         <version>26.2.0</version>
         </dependency>
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-core</artifactId>
-            <version>${keycloak.version}</version>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-core</artifactId>
+        <version>26.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
         <version>26.2.0</version>
         </dependency>
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-services</artifactId>
-            <version>${keycloak.version}</version>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-services</artifactId>
+        <version>26.2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-server-spi</artifactId>
-            <version>${keycloak.version}</version>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-server-spi</artifactId>
+        <version>26.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>


### PR DESCRIPTION
# Dependency Upgrade: org.keycloak:keycloak-services

## Summary
This pull request upgrades the `org.keycloak:keycloak-services` dependency from version `${keycloak.version}` to `26.2.0`. The upgrade aims to keep the project up-to-date with the latest Keycloak releases and benefits from any bug fixes, security patches, or new features included in the newer version.

## Motivation
The motivation behind this dependency upgrade is unclear based on the provided information. The `update_type` is marked as "unknown," and there are no reported vulnerabilities associated with the current version. The priority of this upgrade is considered "low."

## Potential Risks and Mitigations
The impact of upgrading the `org.keycloak:keycloak-services` dependency from `${keycloak.version}` to `26.2.0` is uncertain due to the lack of specific code examples demonstrating how the dependency is used within the project. Without concrete code references, it is challenging to assess the potential risks accurately.

To mitigate any risks, the following steps should be taken:
1. Thoroughly review the Keycloak release notes and migration guides for any breaking changes, API modifications, or deprecated methods between the current version and `26.2.0`.
2. Investigate any compilation errors or warnings that arise after updating the dependency version and make necessary code changes based on the Keycloak documentation and API references.
3. Conduct comprehensive testing of the application to ensure that the upgrade does not introduce runtime errors or unexpected behavior, especially in areas that interact with Keycloak services or rely on Keycloak-specific functionality.

## Testing
Automated tests were attempted using the `pytest` framework, but the test execution failed with the following error:
```
[WinError 2] The system cannot find the file specified
```
This suggests that there may be issues with the test setup or configuration. Further investigation and resolution of the test failure are required before proceeding with the dependency upgrade.

## Manual Verification Steps
Due to the lack of automated test coverage, manual verification steps should be performed to ensure the stability and correctness of the application after the dependency upgrade:
1. Build and run the application with the updated `org.keycloak:keycloak-services` dependency version.
2. Perform thorough manual testing of all functionality related to Keycloak services, including authentication, authorization, and any custom integrations.
3. Verify that the application behaves as expected and that there are no runtime errors or unexpected behavior.
4. If any issues are encountered during manual verification, investigate and address them before merging the pull request.

## Conclusion
This pull request upgrades the `org.keycloak:keycloak-services` dependency to version `26.2.0`. However, due to the lack of specific code examples and the failure of automated tests, it is recommended to proceed with caution. Thorough manual verification and testing should be performed to ensure the stability and correctness of the application after the upgrade.

If you encounter any challenges or need further assistance during the upgrade process, please consult the Keycloak community forums, issue trackers, or seek guidance from the Keycloak documentation and support channels.